### PR TITLE
Tags Fix

### DIFF
--- a/backend/serve.py
+++ b/backend/serve.py
@@ -501,7 +501,7 @@ def list_services(all=""):
     if all == "":
         return (
             json.dumps(
-                [x["name"] for x in mongo_client["labyrinth"]["services"].find({})],
+                [x["display_name"] for x in mongo_client["labyrinth"]["services"].find({})],
                 default=str,
             ),
             200,
@@ -1252,22 +1252,29 @@ def dashboard(val="", report=False):
                 result = mc.judge_port(latest_metric, service, host, stale_time=10000)
             else:
                 found_service = mongo_client["labyrinth"]["services"].find_one(
-                    {"name": service}
+                    {"display_name": service}
                 )
 
-                find_clause["name"] = service
+                if found_service and "display_name" in found_service:
 
-                
-                latest_metric = mongo_client["labyrinth"]["metrics"].find_one(
-                    find_clause,
-                    sort=[("timestamp", pymongo.DESCENDING)],
-                )
-                
+                    find_clause["name"] = found_service["name"]
+                    
+                    if "tag_name" in found_service and found_service["tag_name"] and "tag_value" in found_service:
+                        find_clause["tags.{}".format(found_service["tag_name"])] = found_service["tag_value"]
 
-                if latest_metric is None or found_service is None:
+                    latest_metric = mongo_client["labyrinth"]["metrics"].find_one(
+                        find_clause,
+                        sort=[("timestamp", pymongo.DESCENDING)],
+                    )
+
+
+                    if not latest_metric:
+                        result = False
+                    else:
+                        result = mc.judge(latest_metric, found_service)
+                else: 
                     result = False
-                else:
-                    result = mc.judge(latest_metric, found_service)
+                    
 
             # Alerting section - this code is tested elsewhere
             if (
@@ -1481,12 +1488,19 @@ def read_metrics(host, service="", count=10):
     Returns the latest metrics for a given host
     """
     or_clause = {"$or": [{"tags.host": host}, {"tags.ip": host}, {"tags.mac": host}]}
-    if service != "":
-        or_clause["name"] = service
 
     found_host = mongo_client["labyrinth"]["hosts"].find_one(
         {"$or": [{"mac": host}, {"ip": host}]}
     )
+    
+    found_service = mongo_client["labyrinth"]["services"].find_one(
+            {"display_name": service}
+    )
+
+    if service != "" and found_service:
+        or_clause["name"] = found_service["name"]
+        if "tag_name" in found_service and found_service["tag_name"] and "tag_value" in found_service:
+            or_clause["tags.{}".format(found_service["tag_name"])] = found_service["tag_value"]
 
     retval = [
         x
@@ -1501,9 +1515,7 @@ def read_metrics(host, service="", count=10):
                 item, service, found_host, stale_time=10000
             )
     else:
-        found_service = mongo_client["labyrinth"]["services"].find_one(
-            {"name": service}
-        )
+        
         for item in retval:
             if item is None or found_service is None:
                 item["judgement"] = False

--- a/backend/serve.py
+++ b/backend/serve.py
@@ -1238,29 +1238,31 @@ def dashboard(val="", report=False):
             if "host" in host and host["host"] != "":
                 or_clause.append({"tags.host" : host["host"]})
             """
-
+            find_clause = {
+                "$or" : or_clause
+            }
             if service.strip() == "open_ports" or service.strip() == "closed_ports":
+                find_clause["name"] = "open_ports"
                 latest_metric = mongo_client["labyrinth"]["metrics"].find_one(
-                    {
-                        "name": "open_ports",
-                        "$or": or_clause,
-                    },
+                    find_clause,
                     sort=[("timestamp", pymongo.DESCENDING)],
                 )
                 found_service = service
 
                 result = mc.judge_port(latest_metric, service, host, stale_time=10000)
             else:
-                latest_metric = mongo_client["labyrinth"]["metrics"].find_one(
-                    {
-                        "name": service,
-                        "$or": or_clause,
-                    },
-                    sort=[("timestamp", pymongo.DESCENDING)],
-                )
                 found_service = mongo_client["labyrinth"]["services"].find_one(
                     {"name": service}
                 )
+
+                find_clause["name"] = service
+
+                
+                latest_metric = mongo_client["labyrinth"]["metrics"].find_one(
+                    find_clause,
+                    sort=[("timestamp", pymongo.DESCENDING)],
+                )
+                
 
                 if latest_metric is None or found_service is None:
                     result = False

--- a/frontend/labyrinth/src/components/CreateEditHost.vue
+++ b/frontend/labyrinth/src/components/CreateEditHost.vue
@@ -362,8 +362,8 @@ export default {
         .then((res) => {
           this.services = res.map((x) => {
             return {
-              text: x.name,
-              value: x.name,
+              text: x.display_name,
+              value: x.display_name,
             };
           });
         })

--- a/frontend/labyrinth/src/views/Checks.vue
+++ b/frontend/labyrinth/src/views/Checks.vue
@@ -18,7 +18,19 @@
           <b-button @click="cancel()" class="float-right"> Cancel </b-button>
         </div>
       </template>
-
+      {{selected_service}}
+      <b-row>
+        <b-col
+          ><b>Display Name</b><br />
+          <span class="helptext">Display name.  E.g. cpu-34</span>
+        </b-col>
+        <b-col>
+          <b-input
+            :state="!$v.selected_service.display_name.$invalid"
+            v-model="selected_service.display_name"
+            placeholder="E.g. cpu-32"
+        /></b-col>
+      </b-row>
       <b-row>
         <b-col
           ><b>Exact Service Name</b><br />
@@ -94,6 +106,16 @@
             placeholder="E.g. 100"
         /></b-col>
       </b-row>
+      <hr />
+      <b-row>
+        <b-col>
+          Tags:
+          </b-col>
+          <b-col>
+            
+          </b-col>
+
+        </b-row>
     </b-modal>
 
     <div class="metrics-table">
@@ -130,7 +152,7 @@
         striped
         v-else
       >
-        <template v-slot:cell(name)="row">
+        <template v-slot:cell(display_name)="row">
           <b-button
             variant="link"
             class="shadow-none"
@@ -143,8 +165,11 @@
           >
             <font-awesome-icon icon="edit" size="1x" />
           </b-button>
-          {{ row.item.name }}
+          {{ row.item.display_name }}
         </template>
+        <template v-slot:cell(value)="row">
+          {{row.item.comparison}}&nbsp;{{row.item.value}}
+          </template>
       </b-table>
     </div>
     <hr />
@@ -203,11 +228,11 @@ export default {
       services: [],
       comparison_types: ["greater", "less", "equal"],
       service_fields: [
+        "display_name",
         "name",
         "type",
         "field",
         "metric",
-        "comparison",
         "value",
       ],
       metrics: [],
@@ -216,6 +241,7 @@ export default {
   },
   validations: {
     selected_service: {
+      display_name: {required},
       type: { required },
       name: { required },
       metric: { required },

--- a/frontend/labyrinth/src/views/Checks.vue
+++ b/frontend/labyrinth/src/views/Checks.vue
@@ -108,14 +108,16 @@
       <hr />
       <b-row>
         <b-col>
-          <b>Tags</b><hr />
-          For Example:<br /><code>cpu: cpu-total</code>
+          <b>Tags</b>
+          <div class="helptext mt-2">
+          Additional tags to match.  Used for when there are multiple services checking different resources (i.e. multiple disks being checked for space)
+          </div>
           </b-col>
           <b-col>
             Name: <br />
-            <b-input v-model="selected_service.tag_name" />
+            <b-input class="mb-2" v-model="selected_service.tag_name" placeholder="E.g. cpu"/>
             Value: <br />
-            <b-input v-model="selected_service.tag_value" />
+            <b-input v-model="selected_service.tag_value" placeholder="E.g. cpu-total"/>
             
           </b-col>
 

--- a/frontend/labyrinth/src/views/Checks.vue
+++ b/frontend/labyrinth/src/views/Checks.vue
@@ -18,7 +18,6 @@
           <b-button @click="cancel()" class="float-right"> Cancel </b-button>
         </div>
       </template>
-      {{selected_service}}
       <b-row>
         <b-col
           ><b>Display Name</b><br />
@@ -109,9 +108,14 @@
       <hr />
       <b-row>
         <b-col>
-          Tags:
+          <b>Tags</b><hr />
+          For Example:<br /><code>cpu: cpu-total</code>
           </b-col>
           <b-col>
+            Name: <br />
+            <b-input v-model="selected_service.tag_name" />
+            Value: <br />
+            <b-input v-model="selected_service.tag_value" />
             
           </b-col>
 


### PR DESCRIPTION
Matching metrics to an additional tag.  We were matching to host/ip/mac, but we can have multiple metrics with the same name (example: monitoring disk space on several different disks)