### PR TITLE
Fix false-positive QEMU agent alerts from transient Proxmox connection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ data/**
 docker-compose.yml
 frontend/labyrinth/vue.config.js
 frontend/labyrinth/dist.tar
+.armada/
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,9 @@ Labyrinth is a network analyzer, mapper, and monitor built on NMap, Ansible, and
 - `frontend/labyrinth/` - Vue 2 SPA with Bootstrap-Vue for UI, Konva canvas for network topology visualization
 - `alertmanager/` - Prometheus Alertmanager for alert routing
 - `nginx/` - Reverse proxy with lego for SSL cert management
-- `cron/` - Scheduled jobs (crontab in `cron/cron.d/crontab`) running finder, alive checks, watcher, Proxmox refresh/disk-check, bulk metric writes, AI summaries
+- `cron/` - Scheduled jobs (crontab in `cron/cron.d/crontab`) running finder, alive checks, watcher, Proxmox refresh/disk-check, bulk metric writes, AI summaries, level expiry
+- `backend/ai/` - hourly AI summary job (`ai.sh` -> `backend/ai/main.py`) that pulls hosts/services/recent metrics from Mongo, sends them to ChatGPT (`chatgpt_helper.py`) for a plain-English summary, and delivers it by email/Slack (`email_helper.py`, `slack_helper.py`)
+- `backend/ai/mcp/` - standalone MCP server (own Dockerfile, runs as the `mcp` compose service on port 8765) exposing host/service/metric tools via `unwrap()`-wrapped Flask handlers, bypassing HTTP auth for trusted-network agent access
 - MongoDB - primary data store (hosts, subnets, services, metrics, settings, proxmox_clusters)
 - Redis - write cache for metrics + temporary storage (Telegraf configs, scan output, autosave, job status, Proxmox cluster/guest status caches)
 
@@ -22,7 +24,7 @@ Labyrinth is a network analyzer, mapper, and monitor built on NMap, Ansible, and
 2. Telegraf agents collect metrics and POST to `/metrics` with a `TELEGRAF_KEY` header (checked via the `requires_header` decorator, not Auth0)
 3. Metrics are written to Redis first, then bulk-moved to MongoDB by `cron/bulk_write.sh`
 4. Frontend polls the backend API to display topology and metrics
-5. `backend/watcher.py` judges service health and sends alerts to Alertmanager (`http://alertmanager:9093/api/v2/alerts`); frontend can list/resolve them via `/alertmanager/alerts`
+5. `backend/watcher.py` judges service health and sends alerts to Alertmanager (`http://alertmanager:9093/api/v2/alerts`, password read from `/alertmanager/pass`); frontend can list/resolve them via `/alertmanager/alerts`
 6. Proxmox: `cron/proxmox_refresh.sh` refreshes the per-cluster Redis cache; `cron/disk_check.sh` runs `backend/proxmox_disk_check.py` hourly to email disk-space alerts
 
 ### Proxmox disk-space monitoring (`backend/proxmox_helper.py`, `backend/proxmox_disk_check.py`)
@@ -35,16 +37,22 @@ Labyrinth is a network analyzer, mapper, and monitor built on NMap, Ansible, and
 - `collect_disk_issues` in `proxmox_disk_check.py` turns cluster payloads into threshold-based issues (datastore/vm/container) and always surfaces VMs whose QEMU guest agent is inferred missing, regardless of threshold - a running VM with `maxdisk > 0` and `disk == 0` is a real "we can't measure this" case, not a clean bill of health.
 - Email alerts render via Jinja2 (`backend/templates/disk_space_alert.html`, autoescaped) through `email_helper`.
 
+### AI summaries and MCP (`backend/ai/`)
+
+- `cron/ai.sh` runs `backend/ai/main.py` hourly: `process_dashboard()` pulls hosts/services and recent metrics from MongoDB, slims them down, and `main()` sends the result to ChatGPT (`chatgpt_helper.py`) using a prompt template (`initial_prompt.txt`, gitignored - see `initial_prompt.txt.example`) to produce a plain-English network summary, delivered via `email_helper.py`/`slack_helper.py`.
+- `backend/ai/mcp/server.py` is a separate MCP (Model Context Protocol) server, run as its own Docker service (`mcp` in compose files) with its own `Dockerfile`/`requirements.txt`. It shares the backend's MongoDB/Redis and calls `serve.py` route handlers directly via `unwrap()`, so it exposes host/service/metric management tools (`mcp_list_hosts`, `mcp_create_or_update_host`, `mcp_add_service_to_host`, `mcp_list_services`, `mcp_read_metrics`, etc.) without HTTP auth - intended for trusted-network agent access only. Full tool/schema docs in `backend/ai/mcp/README.md`.
+
 ## Development Workflows
 
 **Start development environment:**
 ```bash
 ./start_dev.sh  # sets up Auth0, alertmanager, SSL certs, then starts docker-compose-development.yml
 ```
-- Frontend dev server: port 8100 (hot reload) / port 8101 (live frontend)
+- Frontend dev server: port 8001 (hot reload) / port 8002 (live frontend) - see `devel` service in `docker-compose-development.yml`
 - Backend API: port 7000
 - NGINX/SSL: port 7210 (Caddy uses an internal dev CA - accept its cert in-browser)
 - MongoDB: localhost:27017, Mongo Express: port 8071
+- MCP server: port 8765 (internal to the `labyrinth` docker network)
 
 **Backend tests:**
 ```bash
@@ -108,5 +116,7 @@ docker-compose -f docker-compose-production.yml up --build -d
 - `backend/ansible_helper.py` - Ansible validation/execution
 - `backend/proxmox_helper.py` / `backend/proxmox_disk_check.py` - Proxmox cluster querying, caching, and disk-space alert emails
 - `backend/watcher.py` - Alertmanager alert dispatch
+- `backend/ai/main.py` - hourly AI dashboard summary job
+- `backend/ai/mcp/server.py` - MCP server exposing host/service/metric tools
 - `cron/run.sh`, `cron/cron.d/crontab` - scheduled job definitions
 - `start_dev.sh` - development environment bootstrap

--- a/backend/proxmox_disk_check.py
+++ b/backend/proxmox_disk_check.py
@@ -173,6 +173,15 @@ def _collect_vm_issues(node, cluster_name, host, node_name, threshold_percent):
             redis_fallback_exhausted = bool(
                 vm.get("_status_live_check_failed") and not vm.get("_status_from_cache")
             )
+            # Same idea, but for the separate agent/info call: a connection
+            # failure there (e.g. a transient timeout to Proxmox) is not the
+            # same as Proxmox actually reporting the agent missing, so it
+            # gets its own cache/fallback tracking - see
+            # proxmox_helper.ProxmoxClient.get_vm_agent_status.
+            agent_check_inconclusive = bool(
+                vm.get("_agent_status_live_check_failed")
+                and not vm.get("_agent_status_from_cache")
+            )
             issues.append(
                 {
                     "type": "vm_qemu_missing",
@@ -187,6 +196,8 @@ def _collect_vm_issues(node, cluster_name, host, node_name, threshold_percent):
                     "qemu_agent_error": vm.get("qemu_guest_agent_error"),
                     "redis_fallback_key": vm.get("_status_cache_key"),
                     "redis_fallback_exhausted": redis_fallback_exhausted,
+                    "agent_redis_fallback_key": vm.get("_agent_status_cache_key"),
+                    "agent_check_inconclusive": agent_check_inconclusive,
                 }
             )
             continue

--- a/backend/proxmox_helper.py
+++ b/backend/proxmox_helper.py
@@ -431,14 +431,20 @@ class ProxmoxClient:
             return None
 
     def get_vm_agent_status(self, node: str, vmid: str) -> Dict:
-        """Determine whether the QEMU guest agent is available for a VM."""
+        """Determine whether the QEMU guest agent is available for a VM.
+
+        `reachable` distinguishes a real answer from Proxmox (HTTP error
+        response - the agent genuinely isn't there) from a failure to even
+        reach Proxmox (connection error/timeout - `installed` is left as
+        `None` since we have no idea, rather than falsely asserting "No").
+        """
         try:
             response = self.session.get(
                 f"{self.base_url}/nodes/{node}/qemu/{vmid}/agent/info",
                 timeout=10,
             )
             response.raise_for_status()
-            return {"installed": True, "error": None}
+            return {"installed": True, "error": None, "reachable": True}
         except requests.HTTPError as error:
             response = getattr(error, "response", None)
             message = None
@@ -459,11 +465,13 @@ class ProxmoxClient:
             return {
                 "installed": False,
                 "error": message or str(error),
+                "reachable": True,
             }
         except Exception as error:
             return {
-                "installed": False,
+                "installed": None,
                 "error": str(error),
+                "reachable": False,
             }
 
     def get_vm_guest_fsinfo(self, node: str, vmid: str) -> Optional[Dict]:
@@ -743,10 +751,47 @@ def _add_vm_info(
                 used_cached_status = True
 
         agent_status = client.get_vm_agent_status(node_name, str(vmid))
+        agent_used_cached_status = False
+        agent_live_check_failed = not agent_status.get("reachable", True)
+        agent_cache_key = None
+
+        if cluster_identifier is not None:
+            agent_cache_key = get_guest_status_cache_key(
+                cluster_identifier, node_name, "vm-agent", vmid
+            )
+
+        if agent_status.get("reachable", True):
+            if cluster_identifier is not None:
+                set_cached_guest_status(
+                    cluster_identifier,
+                    node_name,
+                    "vm-agent",
+                    vmid,
+                    agent_status,
+                    redis_client=redis_client,
+                )
+        elif cluster_identifier is not None:
+            # Couldn't reach Proxmox to ask about the agent at all - fall
+            # back to the last known-good answer instead of reporting a
+            # confident "agent missing" from a single connection blip.
+            cached_agent_status = get_cached_guest_status(
+                cluster_identifier,
+                node_name,
+                "vm-agent",
+                vmid,
+                redis_client=redis_client,
+            )
+            if cached_agent_status is not None:
+                agent_status = cached_agent_status
+                agent_used_cached_status = True
+
         vm_info = _build_vm_info(vm, vm_status, agent_status, client, node_name)
         vm_info["_status_from_cache"] = used_cached_status
         vm_info["_status_live_check_failed"] = live_check_failed
         vm_info["_status_cache_key"] = cache_key
+        vm_info["_agent_status_from_cache"] = agent_used_cached_status
+        vm_info["_agent_status_live_check_failed"] = agent_live_check_failed
+        vm_info["_agent_status_cache_key"] = agent_cache_key
         node_info["vms"].append(vm_info)
 
 
@@ -832,8 +877,12 @@ def _build_vm_info(vm, vm_status, agent_status, client, node_name) -> Dict:
     disk = vm_status.get("disk") if vm_status else None
     is_running = str(vm.get("status") or "").lower() == "running"
 
-    # Determine if QEMU guest agent is truly installed
-    qemu_truly_installed = agent_status.get("installed", False)
+    # Determine if QEMU guest agent is confirmed installed. `installed` may
+    # be None when the live check couldn't reach Proxmox at all and no
+    # cached answer was available - that's "unknown", not "not installed",
+    # so only a definite True counts here.
+    agent_installed = agent_status.get("installed")
+    qemu_truly_installed = agent_installed is True
 
     # Try to get real disk info from guest if agent is installed and disk shows zero
     disk, maxdisk, guest_disk_info = _get_guest_disk_info(
@@ -851,7 +900,7 @@ def _build_vm_info(vm, vm_status, agent_status, client, node_name) -> Dict:
         "disk": disk,
         "maxmem": vm.get("maxmem"),
         "mem": vm_status.get("mem") if vm_status else None,
-        "qemu_guest_agent_installed": qemu_truly_installed,
+        "qemu_guest_agent_installed": agent_installed,
         "qemu_guest_agent_error": agent_status.get("error"),
         "qemu_guest_agent_warning_inferred": qemu_warning_inferred,
     }

--- a/backend/templates/disk_space_alert.html
+++ b/backend/templates/disk_space_alert.html
@@ -105,9 +105,22 @@
                 <td>{{ vm.name }} (ID: {{ vm.vm_id }})</td>
                 <td>{{ vm.status }}</td>
                 <td>{{ vm.maxdisk|format_size }}</td>
-                <td class="percentage-high">{{ "Yes" if vm.qemu_agent_installed else "No" }}</td>
+                <td class="percentage-high">
+                    {% if vm.qemu_agent_installed == true %}Yes{% elif vm.qemu_agent_installed == false %}No{% else %}Unknown{% endif %}
+                </td>
                 <td>
                     {{ vm.qemu_agent_error or "Guest agent unavailable or not reporting filesystem info" }}
+                    {% if vm.agent_check_inconclusive %}
+                    <br>
+                    <span style="color: #8B0000; font-size: 12px;">
+                        Could not verify guest agent status &mdash; the live check to Proxmox
+                        failed and no cached fallback was available
+                        (Redis key: <code>{{ vm.agent_redis_fallback_key }}</code>) &mdash; either
+                        it was never cached, or more than two hours have passed since the last
+                        successful check. Disk usage still cannot be verified, but this may be a
+                        transient connectivity issue rather than a genuinely missing agent.
+                    </span>
+                    {% endif %}
                     {% if vm.redis_fallback_exhausted %}
                     <br>
                     <span style="color: #8B0000; font-size: 12px;">

--- a/backend/test/test_13_proxmox_helper.py
+++ b/backend/test/test_13_proxmox_helper.py
@@ -413,11 +413,19 @@ def test_add_vm_info_caches_successful_status(mock_redis):
         redis_client=mock_redis,
     )
 
-    mock_redis.setex.assert_called_once_with(
+    # Both the VM status and the (separately cached) agent-info answer are
+    # written to their own Redis keys.
+    mock_redis.setex.assert_any_call(
         "proxmox-guest-status:cluster-1:node-a:vm:100",
         proxmox_helper.PROXMOX_GUEST_STATUS_CACHE_TTL_SECONDS,
         json.dumps({"disk": 500, "mem": 100}),
     )
+    mock_redis.setex.assert_any_call(
+        "proxmox-guest-status:cluster-1:node-a:vm-agent:100",
+        proxmox_helper.PROXMOX_GUEST_STATUS_CACHE_TTL_SECONDS,
+        json.dumps({"installed": True, "error": None}),
+    )
+    assert mock_redis.setex.call_count == 2
     vm_info = node_info["vms"][0]
     assert vm_info["disk"] == 500
     assert vm_info["_status_from_cache"] is False
@@ -453,8 +461,15 @@ def test_add_vm_info_falls_back_to_cache_when_status_call_fails(mock_redis):
     assert (
         vm_info["_status_cache_key"] == "proxmox-guest-status:cluster-1:node-a:vm:100"
     )
-    # A failed call must not overwrite the last known-good cached value.
-    mock_redis.setex.assert_not_called()
+    # A failed status call must not overwrite the last known-good cached
+    # value for that key (the successful agent-info check still caches
+    # under its own separate key).
+    vm_status_calls = [
+        call
+        for call in mock_redis.setex.call_args_list
+        if call.args[0] == "proxmox-guest-status:cluster-1:node-a:vm:100"
+    ]
+    assert vm_status_calls == []
 
 
 def test_add_vm_info_no_cache_available_on_failed_status_call(mock_redis):
@@ -484,6 +499,120 @@ def test_add_vm_info_no_cache_available_on_failed_status_call(mock_redis):
     assert (
         vm_info["_status_cache_key"] == "proxmox-guest-status:cluster-1:node-a:vm:100"
     )
+
+
+def test_add_vm_info_agent_check_falls_back_to_cache_on_connection_failure(mock_redis):
+    """A transient connection failure to the agent/info endpoint (e.g. a
+    timeout reaching Proxmox) must not be reported as a confirmed 'agent
+    missing' - it should fall back to the last known-good agent answer,
+    same as the VM status/disk check already does."""
+    client = Mock()
+    client.get_vm_status.return_value = {"disk": 0, "mem": 100}
+    client.get_vm_agent_status.return_value = {
+        "installed": None,
+        "error": "ConnectTimeoutError(...)",
+        "reachable": False,
+    }
+    client.get_vm_guest_fsinfo.return_value = None
+    mock_redis.get.return_value = json.dumps({"installed": True, "error": None}).encode(
+        "utf-8"
+    )
+
+    node_info = {"vms": []}
+    proxmox_helper._add_vm_info(
+        node_info,
+        client,
+        "node-a",
+        [{"vmid": 109, "name": "venus", "status": "running", "maxdisk": 1000}],
+        cluster_identifier="cluster-1",
+        redis_client=mock_redis,
+    )
+
+    vm_info = node_info["vms"][0]
+    # The cached "installed" answer wins over the raw connection error.
+    assert vm_info["qemu_guest_agent_installed"] is True
+    assert vm_info["qemu_guest_agent_error"] is None
+    assert vm_info["_agent_status_from_cache"] is True
+    assert vm_info["_agent_status_live_check_failed"] is True
+    # A cache hit means the live failure must not overwrite the last
+    # known-good agent answer.
+    agent_key_calls = [
+        c
+        for c in mock_redis.setex.call_args_list
+        if c.args[0] == "proxmox-guest-status:cluster-1:node-a:vm-agent:109"
+    ]
+    assert agent_key_calls == []
+
+
+def test_add_vm_info_agent_check_unknown_when_no_cache_available(mock_redis):
+    """When the agent/info call fails to even reach Proxmox and there's no
+    cached fallback, the agent status must be reported as unknown (None),
+    never as a confirmed 'not installed'."""
+    client = Mock()
+    client.get_vm_status.return_value = {"disk": 0, "mem": 100}
+    client.get_vm_agent_status.return_value = {
+        "installed": None,
+        "error": "ConnectTimeoutError(...)",
+        "reachable": False,
+    }
+    mock_redis.get.return_value = None
+
+    node_info = {"vms": []}
+    proxmox_helper._add_vm_info(
+        node_info,
+        client,
+        "node-a",
+        [{"vmid": 109, "name": "venus", "status": "running", "maxdisk": 1000}],
+        cluster_identifier="cluster-1",
+        redis_client=mock_redis,
+    )
+
+    vm_info = node_info["vms"][0]
+    assert vm_info["qemu_guest_agent_installed"] is None
+    assert vm_info["_agent_status_from_cache"] is False
+    assert vm_info["_agent_status_live_check_failed"] is True
+    assert (
+        vm_info["_agent_status_cache_key"]
+        == "proxmox-guest-status:cluster-1:node-a:vm-agent:109"
+    )
+
+
+def test_add_vm_info_agent_check_success_is_cached(mock_redis):
+    """A definitive agent/info answer (installed or not) is cached so a
+    later transient failure has something to fall back to."""
+    client = Mock()
+    client.get_vm_status.return_value = {"disk": 500, "mem": 100}
+    client.get_vm_agent_status.return_value = {
+        "installed": False,
+        "error": "QEMU guest agent is not running",
+        "reachable": True,
+    }
+
+    node_info = {"vms": []}
+    proxmox_helper._add_vm_info(
+        node_info,
+        client,
+        "node-a",
+        [{"vmid": 109, "name": "venus", "status": "running", "maxdisk": 1000}],
+        cluster_identifier="cluster-1",
+        redis_client=mock_redis,
+    )
+
+    mock_redis.setex.assert_any_call(
+        "proxmox-guest-status:cluster-1:node-a:vm-agent:109",
+        proxmox_helper.PROXMOX_GUEST_STATUS_CACHE_TTL_SECONDS,
+        json.dumps(
+            {
+                "installed": False,
+                "error": "QEMU guest agent is not running",
+                "reachable": True,
+            }
+        ),
+    )
+    vm_info = node_info["vms"][0]
+    assert vm_info["qemu_guest_agent_installed"] is False
+    assert vm_info["_agent_status_from_cache"] is False
+    assert vm_info["_agent_status_live_check_failed"] is False
 
 
 def test_add_container_info_caches_successful_status(mock_redis):
@@ -949,7 +1078,7 @@ def test_proxmox_client_get_vm_agent_status_http_error_no_json(mock_session):
 
 
 def test_proxmox_client_get_vm_agent_status_general_exception(mock_session):
-    """Handle general exception."""
+    """A connection-level failure is unknown, not a confirmed 'not installed'."""
     client = proxmox_helper.ProxmoxClient(
         host="10.0.0.1", user="root@pam", token_id="token-1", token_secret="secret-1"
     )
@@ -959,8 +1088,44 @@ def test_proxmox_client_get_vm_agent_status_general_exception(mock_session):
 
     result = client.get_vm_agent_status("node-1", "100")
 
-    assert result["installed"] is False
+    assert result["installed"] is None
+    assert result["reachable"] is False
     assert "timeout" in result["error"]
+
+
+def test_proxmox_client_get_vm_agent_status_success_is_reachable(mock_session):
+    """A successful check is marked reachable so it can be cached."""
+    client = proxmox_helper.ProxmoxClient(
+        host="10.0.0.1", user="root@pam", token_id="token-1", token_secret="secret-1"
+    )
+    client.session = mock_session
+
+    mock_response = Mock()
+    mock_response.json.return_value = {"data": {"supported_commands": []}}
+    mock_session.get.return_value = mock_response
+
+    result = client.get_vm_agent_status("node-1", "100")
+
+    assert result["reachable"] is True
+
+
+def test_proxmox_client_get_vm_agent_status_http_error_is_reachable(mock_session):
+    """A real HTTP error from Proxmox counts as a reachable, definitive answer."""
+    client = proxmox_helper.ProxmoxClient(
+        host="10.0.0.1", user="root@pam", token_id="token-1", token_secret="secret-1"
+    )
+    client.session = mock_session
+
+    http_error = requests.HTTPError()
+    http_response = Mock()
+    http_response.json.return_value = {"errors": "Agent not installed"}
+    http_error.response = http_response
+    mock_session.get.side_effect = http_error
+
+    result = client.get_vm_agent_status("node-1", "100")
+
+    assert result["reachable"] is True
+    assert result["installed"] is False
 
 
 def test_proxmox_client_get_vm_guest_fsinfo_success(mock_session):

--- a/backend/test/test_14_proxmox_disk_check.py
+++ b/backend/test/test_14_proxmox_disk_check.py
@@ -119,6 +119,48 @@ def _cluster_data_with_exhausted_redis_fallback(cluster_name, host):
     }
 
 
+def _cluster_data_with_inconclusive_agent_check(cluster_name, host):
+    """Cluster payload for a VM whose disk-status call succeeded (as is
+    normal for QEMU without an agent - it always reports disk=0) but whose
+    separate agent/info call failed to even reach Proxmox, with nothing left
+    in its own two-hour Redis fallback cache. This is the actual production
+    bug: a transient connection failure to /agent/info alone must not be
+    reported as a confirmed 'agent missing'."""
+    return {
+        "cluster_name": cluster_name,
+        "host": host,
+        "nodes": [
+            {
+                "name": "pve",
+                "storage": [],
+                "vms": [
+                    {
+                        "id": 109,
+                        "name": "venus",
+                        "status": "running",
+                        "maxdisk": 214748364800,
+                        "disk": 0,
+                        "qemu_guest_agent_installed": None,
+                        "qemu_guest_agent_warning_inferred": True,
+                        "qemu_guest_agent_error": (
+                            "HTTPSConnectionPool(host='192.168.0.107', port=8006): "
+                            "Max retries exceeded ... ConnectTimeoutError"
+                        ),
+                        "_status_live_check_failed": False,
+                        "_status_from_cache": False,
+                        "_agent_status_live_check_failed": True,
+                        "_agent_status_from_cache": False,
+                        "_agent_status_cache_key": (
+                            "proxmox-guest-status:south:pve:vm-agent:109"
+                        ),
+                    }
+                ],
+                "containers": [],
+            }
+        ],
+    }
+
+
 # ---------------------------------------------------------------------------
 # collect_disk_issues - unit tests
 # ---------------------------------------------------------------------------
@@ -161,6 +203,29 @@ def test_collect_disk_issues_flags_redis_fallback_exhausted():
     assert issue["type"] == "vm_qemu_missing"
     assert issue["redis_fallback_exhausted"] is True
     assert issue["redis_fallback_key"] == "proxmox-guest-status:cluster-x:node-c:vm:401"
+
+
+def test_collect_disk_issues_flags_agent_check_inconclusive():
+    """A connection failure to /agent/info alone (VM status call succeeded
+    fine) with no cached fallback must be marked inconclusive, not a
+    confirmed missing agent - this is the exact production false-positive
+    reported: a single ConnectTimeoutError to the agent endpoint should not
+    read as 'Agent Installed: No'."""
+    cluster_data = _cluster_data_with_inconclusive_agent_check("south", "192.168.0.107")
+
+    issues = proxmox_disk_check.collect_disk_issues(cluster_data, threshold_percent=80)
+
+    assert len(issues) == 1
+    issue = issues[0]
+    assert issue["type"] == "vm_qemu_missing"
+    assert issue["qemu_agent_installed"] is None
+    assert issue["agent_check_inconclusive"] is True
+    assert issue["agent_redis_fallback_key"] == (
+        "proxmox-guest-status:south:pve:vm-agent:109"
+    )
+    # The VM status check itself succeeded and wasn't served from cache -
+    # this is specifically an agent-check failure, not a status-check one.
+    assert issue["redis_fallback_exhausted"] is False
 
 
 def test_collect_disk_issues_missing_agent_vm_not_double_counted():
@@ -426,6 +491,40 @@ def test_render_email_template_shows_redis_fallback_details_when_exhausted():
 
     assert "no cached fallback was available" in html.lower()
     assert "proxmox-guest-status:cluster-x:node-c:vm:401" in html
+
+
+def test_render_email_template_shows_unknown_and_note_when_agent_check_inconclusive():
+    """A VM whose agent/info call failed with no cached fallback must render
+    'Unknown' (not 'No') in the Agent Installed column, plus an explanatory
+    note - this is the fix for the reported false-positive email, which
+    showed a raw ConnectTimeoutError as if it confirmed the agent was
+    missing."""
+    issues = [
+        {
+            "type": "vm_qemu_missing",
+            "cluster": "south",
+            "host": "192.168.0.107",
+            "node": "pve",
+            "name": "venus",
+            "vm_id": 109,
+            "status": "running",
+            "maxdisk": 214748364800,
+            "qemu_agent_installed": None,
+            "qemu_agent_error": (
+                "HTTPSConnectionPool(host='192.168.0.107', port=8006): "
+                "Max retries exceeded ... ConnectTimeoutError"
+            ),
+            "redis_fallback_exhausted": False,
+            "agent_check_inconclusive": True,
+            "agent_redis_fallback_key": "proxmox-guest-status:south:pve:vm-agent:109",
+        },
+    ]
+
+    html = proxmox_disk_check.render_email_template(issues, threshold_percent=80)
+
+    assert "Unknown" in html
+    assert "Could not verify guest agent status" in html
+    assert "proxmox-guest-status:south:pve:vm-agent:109" in html
 
 
 def test_render_email_template_omits_qemu_missing_section_when_absent():


### PR DESCRIPTION
The agent/info API call had no Redis fallback, unlike the disk-status call, so a single connection timeout to Proxmox was reported as a confirmed "agent missing" with the raw exception as the alert detail. Cache successful/definitive agent answers the same way disk status already is, and report "Unknown" (not "No") when a live check fails with nothing left in the two-hour fallback cache.

Also ignore .armada/ and .claude/ working directories.