### PR TITLE
fix: correct metric timestamps and historical judgement in service gr…

### DIFF
--- a/backend/serve.py
+++ b/backend/serve.py
@@ -1994,10 +1994,20 @@ def read_metrics(host, service="", count=100, option=""):
         .limit(count)
     ]
 
+    # Staleness (vs. wall-clock "now") only makes sense for the single
+    # latest-value fetch, which reflects current live status. Historical
+    # rows should be judged on whether they passed/failed at the time they
+    # were recorded, not on how old they are relative to right now -
+    # otherwise nearly every point in a History graph older than a few
+    # minutes would be marked "-1"/stale and render as a failure.
+    is_latest = option == "latest"
+    port_stale_time = 10000 if is_latest else float("inf")
+    check_stale_time = 600 if is_latest else float("inf")
+
     if service.strip() == "open_ports" or service.strip() == "closed_ports":
         for item in retval:
             item["judgement"] = mc.judge_port(
-                item, service, found_host, stale_time=10000
+                item, service, found_host, stale_time=port_stale_time
             )
             item["judgement_debug"] = {
                 "item": json.dumps(item, default=str),
@@ -2009,10 +2019,23 @@ def read_metrics(host, service="", count=100, option=""):
             if item is None or found_service is None:
                 item["judgement"] = False
             else:
-                item["judgement"] = mc.judge(item, found_service)
+                item["judgement"] = mc.judge(
+                    item, found_service, stale_time=check_stale_time
+                )
+
+    def _sort_key(item):
+        ts = item.get("timestamp")
+        if isinstance(ts, datetime.datetime):
+            return ts.timestamp()
+        try:
+            return float(ts)
+        except (TypeError, ValueError):
+            return 0
+
+    retval.sort(key=_sort_key)
 
     return (
-        json.dumps(retval[::-1], default=str),
+        json.dumps(retval, default=str),
         200,
     )
 
@@ -2085,8 +2108,7 @@ def bulk_insert():
 
         if "timestamp" in item:
             try:
-                # item["timestamp"] = datetime.datetime.fromtimestamp(item["timestamp"])
-                item["timestamp"] = datetime.datetime.now()
+                item["timestamp"] = datetime.datetime.fromtimestamp(item["timestamp"])
             except Exception:
                 print("Problem with timestamp - ", sys.exc_info())
 

--- a/backend/test/test_04_metrics.py
+++ b/backend/test/test_04_metrics.py
@@ -85,6 +85,131 @@ def test_read_metrics(setup):
         assert b[0]["timestamp"] == 2
 
 
+def test_read_metrics_history_ignores_staleness(setup):
+    """
+    History rows must be judged on whether they passed/failed at the time
+    they were recorded, not on how old they are relative to "now" - a
+    History graph intentionally spans well beyond the 600s staleness window
+    used for live/current status.
+    """
+    serve.mongo_client["labyrinth"]["services"].delete_many(
+        {"display_name": "old-check"}
+    )
+    serve.mongo_client["labyrinth"]["services"].insert_one(
+        {
+            "display_name": "old-check",
+            "name": "old-check",
+            "type": "check",
+            "metric": "value",
+            "comparison": "equals",
+            "value": "ok",
+        }
+    )
+
+    old_timestamp = time.time() - 7200  # 2 hours old, well past stale_time=600
+    serve.mongo_client["labyrinth"]["metrics"].insert_one(
+        {
+            "timestamp": old_timestamp,
+            "name": "old-check",
+            "fields": {"value": "ok"},
+            "tags": {
+                "host": "history-host",
+                "ip": "history-host",
+                "mac": "history-host",
+                "labyrinth_name": "old-check",
+            },
+        }
+    )
+
+    a = unwrap(serve.read_metrics)("history-host", "old-check")
+    assert a[1] == 200
+    b = json.loads(a[0])
+    assert len(b) == 1
+    assert b[0]["judgement"] is True
+
+
+def test_read_metrics_latest_still_applies_staleness(setup):
+    """
+    The dedicated "latest" fetch reflects current live status, so an old
+    latest-value record should still be judged stale ("-1").
+    """
+    serve.mongo_client["labyrinth"]["services"].delete_many(
+        {"display_name": "old-check"}
+    )
+    serve.mongo_client["labyrinth"]["services"].insert_one(
+        {
+            "display_name": "old-check",
+            "name": "old-check",
+            "type": "check",
+            "metric": "value",
+            "comparison": "equals",
+            "value": "ok",
+        }
+    )
+
+    old_timestamp = time.time() - 7200
+    serve.mongo_client["labyrinth"]["metrics-latest"].insert_one(
+        {
+            "timestamp": old_timestamp,
+            "name": "old-check",
+            "fields": {"value": "ok"},
+            "tags": {
+                "host": "history-host-2",
+                "ip": "history-host-2",
+                "mac": "history-host-2",
+                "labyrinth_name": "old-check",
+            },
+        }
+    )
+
+    a = unwrap(serve.read_metrics)("history-host-2", "old-check", 100, "latest")
+    assert a[1] == 200
+    b = json.loads(a[0])
+    assert len(b) == 1
+    assert b[0]["judgement"] == -1
+
+
+def test_read_metrics_orders_by_metric_timestamp(setup):
+    """
+    Mongo insertion order (_id) can diverge from a metric's own timestamp
+    (e.g. bulk-write sweep jitter). read_metrics must order its response by
+    each point's own timestamp, not by insertion order, or a History graph's
+    x-axis ends up out of order.
+    """
+    now = time.time()
+
+    # Insert the newer point first (smaller _id) and the older point second
+    # (larger _id) - deliberately the opposite of chronological order.
+    serve.mongo_client["labyrinth"]["metrics"].insert_one(
+        {
+            "timestamp": now,
+            "name": "order-check",
+            "tags": {
+                "host": "order-host",
+                "ip": "order-host",
+                "mac": "order-host",
+            },
+        }
+    )
+    serve.mongo_client["labyrinth"]["metrics"].insert_one(
+        {
+            "timestamp": now - 500,
+            "name": "order-check",
+            "tags": {
+                "host": "order-host",
+                "ip": "order-host",
+                "mac": "order-host",
+            },
+        }
+    )
+
+    a = unwrap(serve.read_metrics)("order-host")
+    assert a[1] == 200
+    b = json.loads(a[0])
+    assert len(b) == 2
+    assert b[0]["timestamp"] < b[1]["timestamp"]
+
+
 def test_time_judge(setup):
     """
     Tests time judgement

--- a/backend/test/test_17_serve_coverage.py
+++ b/backend/test/test_17_serve_coverage.py
@@ -8,6 +8,7 @@ metrics handling, and sanitization functions.
 import json
 import os
 import io
+import time
 import pytest
 import datetime
 import yaml
@@ -508,6 +509,37 @@ def test_bulk_insert_timestamp_handling(setup):
             resp = unwrap(serve.bulk_insert)()
 
         assert resp[1] == 200
+    finally:
+        a.close()
+
+
+def test_bulk_insert_preserves_metric_timestamp(setup):
+    """bulk_insert must preserve the metric's own timestamp instead of
+    substituting the wall-clock time it happened to be swept from Redis -
+    otherwise History graphs plot points at sweep time instead of when the
+    metric was actually collected."""
+    a = redis.Redis(host=os.environ.get("REDIS_HOST") or "redis")
+    try:
+        original_timestamp = time.time() - 7200  # 2 hours ago
+        metric = {
+            "name": "cpu",
+            "tags": {"ip": "192.168.1.9", "host": "server9"},
+            "value": 12.3,
+            "timestamp": original_timestamp,
+        }
+        metric_key = f"METRIC-{json.dumps({'name': metric['name'], 'tags': metric['tags']}, default=str)}"
+        a.set(metric_key, json.dumps(metric, default=str))
+
+        with serve.app.test_request_context("/bulk_insert/", method="GET"):
+            resp = unwrap(serve.bulk_insert)()
+
+        assert resp[1] == 200
+
+        stored = serve.mongo_client["labyrinth"]["metrics"].find_one(
+            {"tags.ip": "192.168.1.9"}
+        )
+        assert stored is not None
+        assert abs(stored["timestamp"].timestamp() - original_timestamp) < 5
     finally:
         a.close()
 
@@ -1252,8 +1284,12 @@ def test_bulk_insert_with_exception(
         None,  # last_time returns None
     ]
 
-    # Mock datetime.now() to return an actual datetime object
+    # Mock datetime.now()/fromtimestamp() to return an actual datetime object,
+    # since bulk_insert converts each metric's own timestamp field.
     mock_datetime_module.datetime.now.return_value = datetime.datetime(
+        2026, 7, 13, 19, 57, 51
+    )
+    mock_datetime_module.datetime.fromtimestamp.return_value = datetime.datetime(
         2026, 7, 13, 19, 57, 51
     )
 


### PR DESCRIPTION
…aphs

bulk_insert() was overwriting every metric's real timestamp with datetime.now() at sweep time instead of converting the Telegraf-reported timestamp, corrupting the History graph's time axis. read_metrics() also applied the "is this stale right now" judgement gate to historical rows, so any point older than 10 minutes was marked -1/failure regardless of whether it actually passed at the time. Also sort returned history by each point's own timestamp instead of trusting Mongo insertion order.